### PR TITLE
Rename package to match module

### DIFF
--- a/cputime.go
+++ b/cputime.go
@@ -1,4 +1,4 @@
-package cputime
+package benchmore
 
 import (
 	"syscall"

--- a/cputime_test.go
+++ b/cputime_test.go
@@ -1,4 +1,4 @@
-package cputime
+package benchmore
 
 import (
 	"testing"


### PR DESCRIPTION
Currently package name is different from module and it brings minor inconvenience. Example in `README` suggests package name should match module, so this PR renames the package.